### PR TITLE
Add custom ratio / Fix general library issues

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,29 @@
+module.exports = {
+    "env": {
+        "browser": true,
+        "node": true,
+        "mocha": true
+    },
+    "extends": "eslint:recommended",
+    "parserOptions": {
+        "ecmaVersion": 6
+    },
+    "rules": {
+        "indent": [
+            "error",
+            4
+        ],
+        "linebreak-style": [
+            "error",
+            "unix"
+        ],
+        "quotes": [
+            "error",
+            "double"
+        ],
+        "semi": [
+            "error",
+            "always"
+        ]
+    }
+};

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Then do `npm install`
 Usage:
 -----
 
+To check specific WCAG levels
 ```
 var ccc = new ColorContrastChecker();
 
@@ -42,6 +43,22 @@ var color2 = "#000000;
 
 if (ccc.isLevelAA(color1, color2, 14)) {
     alert("Valid Level AA");
+} else {
+    alert("Invalid Contrast");
+}
+
+```
+
+To check custom ratios
+```
+var ccc = new ColorContrastChecker();
+
+var color1 = "#FFFFFF";
+var color2 = "#000000;
+
+// No need for font size, as this is no longer a WCAG req
+if (ccc.isLevelCustom(color1, color2, 5.7)) {
+    alert("Above given ratio");
 } else {
     alert("Invalid Contrast");
 }

--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ var ccc = new ColorContrastChecker();
 var color1 = "#FFFFFF";
 var color2 = "#000000;
 
-// No need for font size, as this is no longer a WCAG req
+// No need for font size, now that we are using a custom ratio.
+// This is because we are no longer checking against WCAG requirements.
 if (ccc.isLevelCustom(color1, color2, 5.7)) {
     alert("Above given ratio");
 } else {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,98 @@
 {
   "name": "color-contrast-checker",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 1,
+  "requires": true,
   "dependencies": {
+    "@babel/code-frame": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
+      "integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
+      "dev": true,
+      "requires": {
+        "@babel/highlight": "^7.0.0"
+      }
+    },
+    "@babel/highlight": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
+      "integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.0.0",
+        "esutils": "^2.0.2",
+        "js-tokens": "^4.0.0"
+      }
+    },
+    "acorn": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.0.5.tgz",
+      "integrity": "sha512-i33Zgp3XWtmZBMNvCr4azvOFeWVw1Rk6p3hfi3LUDvIFraOMywb1kAtrbi+med14m4Xfpqm3zRZMT+c0FNE7kg==",
+      "dev": true
+    },
+    "acorn-jsx": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.0.1.tgz",
+      "integrity": "sha512-HJ7CfNHrfJLlNTzIEUTj43LNWGkqpRLxm3YjAlcD0ACydk9XynzYsCBHxut+iqt+1aBXkx9UP/w/ZqMr13XIzg==",
+      "dev": true
+    },
+    "ajv": {
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.7.0.tgz",
+      "integrity": "sha512-RZXPviBTtfmtka9n9sy1N5M5b82CbxWIR6HIis4s3WQTXDJamc/0gpCWNGz6EWdWp4DOfjzJfhz/AS9zVPjjWg==",
+      "dev": true,
+      "requires": {
+        "fast-deep-equal": "^2.0.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      }
+    },
     "amdefine": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
       "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
     },
+    "ansi-escapes": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+      "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
+      "dev": true
+    },
+    "ansi-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+      "dev": true
+    },
+    "ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "requires": {
+        "color-convert": "^1.9.0"
+      }
+    },
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "requires": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
     "assertion-error": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
       "integrity": "sha1-E8pRXYYgbaC6xm6DTdOX2HWBCUw=",
+      "dev": true
+    },
+    "astral-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
+      "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
       "dev": true
     },
     "balanced-match": {
@@ -24,7 +105,11 @@
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
       "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
     },
     "browser-stdout": {
       "version": "1.3.0",
@@ -32,10 +117,58 @@
       "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
       "dev": true
     },
+    "callsites": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.0.0.tgz",
+      "integrity": "sha512-tWnkwu9YEq2uzlBDI4RcLn8jrFvF9AOi8PxDNU3hZZjJcjkcRAq3vCI+vZcg1SuxISDYe86k9VZFwAxDiJGoAw==",
+      "dev": true
+    },
     "chai": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/chai/-/chai-4.1.0.tgz",
       "integrity": "sha1-MxoDkbVcOvh0CunDt0WLwcOAXm0=",
+      "dev": true,
+      "requires": {
+        "assertion-error": "^1.0.1",
+        "check-error": "^1.0.1",
+        "deep-eql": "^2.0.1",
+        "get-func-name": "^2.0.0",
+        "pathval": "^1.0.0",
+        "type-detect": "^4.0.0"
+      }
+    },
+    "chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "chardet": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true
     },
     "check-error": {
@@ -44,11 +177,50 @@
       "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
       "dev": true
     },
+    "circular-json": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
+      "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
+      "dev": true
+    },
+    "cli-cursor": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+      "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+      "dev": true,
+      "requires": {
+        "restore-cursor": "^2.0.0"
+      }
+    },
+    "cli-width": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
+      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
+      "dev": true
+    },
+    "color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
+    },
     "commander": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
       "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "graceful-readlink": ">= 1.0.0"
+      }
     },
     "concat-map": {
       "version": "0.0.1",
@@ -56,17 +228,36 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
+    "cross-spawn": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+      "dev": true,
+      "requires": {
+        "nice-try": "^1.0.4",
+        "path-key": "^2.0.1",
+        "semver": "^5.5.0",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
+      }
+    },
     "debug": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.0.tgz",
       "integrity": "sha1-vFlryr52F/Edn6FTYe3tVgi4SZs=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ms": "0.7.2"
+      }
     },
     "deep-eql": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-2.0.2.tgz",
       "integrity": "sha1-sbrAblbwp2d3aG1Qyf63XC7XZ5o=",
       "dev": true,
+      "requires": {
+        "type-detect": "^3.0.0"
+      },
       "dependencies": {
         "type-detect": {
           "version": "3.0.0",
@@ -76,11 +267,26 @@
         }
       }
     },
+    "deep-is": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+      "dev": true
+    },
     "diff": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
       "integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k=",
       "dev": true
+    },
+    "doctrine": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+      "dev": true,
+      "requires": {
+        "esutils": "^2.0.2"
+      }
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -88,10 +294,221 @@
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
     },
+    "eslint": {
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.12.1.tgz",
+      "integrity": "sha512-54NV+JkTpTu0d8+UYSA8mMKAG4XAsaOrozA9rCW7tgneg1mevcL7wIotPC+fZ0SkWwdhNqoXoxnQCTBp7UvTsg==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "ajv": "^6.5.3",
+        "chalk": "^2.1.0",
+        "cross-spawn": "^6.0.5",
+        "debug": "^4.0.1",
+        "doctrine": "^2.1.0",
+        "eslint-scope": "^4.0.0",
+        "eslint-utils": "^1.3.1",
+        "eslint-visitor-keys": "^1.0.0",
+        "espree": "^5.0.0",
+        "esquery": "^1.0.1",
+        "esutils": "^2.0.2",
+        "file-entry-cache": "^2.0.0",
+        "functional-red-black-tree": "^1.0.1",
+        "glob": "^7.1.2",
+        "globals": "^11.7.0",
+        "ignore": "^4.0.6",
+        "import-fresh": "^3.0.0",
+        "imurmurhash": "^0.1.4",
+        "inquirer": "^6.1.0",
+        "js-yaml": "^3.12.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.3.0",
+        "lodash": "^4.17.5",
+        "minimatch": "^3.0.4",
+        "mkdirp": "^0.5.1",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.8.2",
+        "path-is-inside": "^1.0.2",
+        "pluralize": "^7.0.0",
+        "progress": "^2.0.0",
+        "regexpp": "^2.0.1",
+        "semver": "^5.5.1",
+        "strip-ansi": "^4.0.0",
+        "strip-json-comments": "^2.0.1",
+        "table": "^5.0.2",
+        "text-table": "^0.2.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "glob": {
+          "version": "7.1.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+          "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "dev": true
+        }
+      }
+    },
+    "eslint-scope": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.0.tgz",
+      "integrity": "sha512-1G6UTDi7Jc1ELFwnR58HV4fK9OQK4S6N985f166xqXxpjU6plxFISJa2Ba9KCQuFa8RCnj/lSFJbHo7UFDBnUA==",
+      "dev": true,
+      "requires": {
+        "esrecurse": "^4.1.0",
+        "estraverse": "^4.1.1"
+      }
+    },
+    "eslint-utils": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.3.1.tgz",
+      "integrity": "sha512-Z7YjnIldX+2XMcjr7ZkgEsOj/bREONV60qYeB/bjMAqqqZ4zxKyWX+BOUkdmRmA9riiIPVvo5x86m5elviOk0Q==",
+      "dev": true
+    },
+    "eslint-visitor-keys": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
+      "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
+      "dev": true
+    },
+    "espree": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-5.0.0.tgz",
+      "integrity": "sha512-1MpUfwsdS9MMoN7ZXqAr9e9UKdVHDcvrJpyx7mm1WuQlx/ygErEQBzgi5Nh5qBHIoYweprhtMkTCb9GhcAIcsA==",
+      "dev": true,
+      "requires": {
+        "acorn": "^6.0.2",
+        "acorn-jsx": "^5.0.0",
+        "eslint-visitor-keys": "^1.0.0"
+      }
+    },
+    "esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true
+    },
+    "esquery": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.1.tgz",
+      "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
+      "dev": true,
+      "requires": {
+        "estraverse": "^4.0.0"
+      }
+    },
+    "esrecurse": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
+      "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
+      "dev": true,
+      "requires": {
+        "estraverse": "^4.1.0"
+      }
+    },
+    "estraverse": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+      "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+      "dev": true
+    },
+    "esutils": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+      "dev": true
+    },
+    "external-editor": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.0.3.tgz",
+      "integrity": "sha512-bn71H9+qWoOQKyZDo25mOMVpSmXROAsTJVVVYzrrtol3d4y+AsKjf4Iwl2Q+IuT0kFSQ1qo166UuIwqYq7mGnA==",
+      "dev": true,
+      "requires": {
+        "chardet": "^0.7.0",
+        "iconv-lite": "^0.4.24",
+        "tmp": "^0.0.33"
+      }
+    },
+    "fast-deep-equal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+      "dev": true
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+      "dev": true
+    },
+    "fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
+    },
+    "figures": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+      "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "^1.0.5"
+      }
+    },
+    "file-entry-cache": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
+      "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
+      "dev": true,
+      "requires": {
+        "flat-cache": "^1.2.1",
+        "object-assign": "^4.0.1"
+      }
+    },
+    "flat-cache": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.4.tgz",
+      "integrity": "sha512-VwyB3Lkgacfik2vhqR4uv2rvebqmDvFu4jlN/C1RzWoJEo8I7z4Q404oiqYCkq41mni8EzQnm95emU9seckwtg==",
+      "dev": true,
+      "requires": {
+        "circular-json": "^0.3.1",
+        "graceful-fs": "^4.1.2",
+        "rimraf": "~2.6.2",
+        "write": "^0.2.1"
+      }
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
     },
     "get-func-name": {
@@ -104,6 +521,26 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
       "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.2",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "globals": {
+      "version": "11.10.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.10.0.tgz",
+      "integrity": "sha512-0GZF1RiPKU97IHUO5TORo9w1PwrH/NBPl+fS7oMLdaTRiYmYbwK4NWoZWrAdd0/abG9R2BU+OiwyQpTpE6pdfQ==",
+      "dev": true
+    },
+    "graceful-fs": {
+      "version": "4.1.15",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
+      "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
       "dev": true
     },
     "graceful-readlink": {
@@ -124,16 +561,135 @@
       "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
       "dev": true
     },
+    "iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dev": true,
+      "requires": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      }
+    },
+    "ignore": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+      "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+      "dev": true
+    },
+    "import-fresh": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.0.0.tgz",
+      "integrity": "sha512-pOnA9tfM3Uwics+SaBLCNyZZZbK+4PTu0OPZtLlMIrv17EdBoC15S9Kn8ckJ9TZTyKb3ywNE5y1yeDxxGA7nTQ==",
+      "dev": true,
+      "requires": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      }
+    },
+    "imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "dev": true
+    },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
     },
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "inquirer": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.2.1.tgz",
+      "integrity": "sha512-088kl3DRT2dLU5riVMKKr1DlImd6X7smDhpXUCkJDCKvTEJeRiXh0G132HG9u5a+6Ylw9plFRY7RuTnwohYSpg==",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "^3.0.0",
+        "chalk": "^2.0.0",
+        "cli-cursor": "^2.1.0",
+        "cli-width": "^2.0.0",
+        "external-editor": "^3.0.0",
+        "figures": "^2.0.0",
+        "lodash": "^4.17.10",
+        "mute-stream": "0.0.7",
+        "run-async": "^2.2.0",
+        "rxjs": "^6.1.0",
+        "string-width": "^2.1.0",
+        "strip-ansi": "^5.0.0",
+        "through": "^2.3.6"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.0.0.tgz",
+          "integrity": "sha512-iB5Dda8t/UqpPI/IjsejXu5jOGDrzn41wJyljwPH65VCIbk6+1BzFIMJGFwTNrYXT1CrD+B4l19U7awiQ8rk7w==",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.0.0.tgz",
+          "integrity": "sha512-Uu7gQyZI7J7gn5qLn1Np3G9vcYGTVqB+lFTytnDJv83dd8T22aGH451P3jueT2/QemInJDfxHB5Tde5OzgG1Ow==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.0.0"
+          }
+        }
+      }
+    },
+    "is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "dev": true
+    },
+    "is-promise": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
+      "dev": true
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
+    },
+    "js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
+    },
+    "js-yaml": {
+      "version": "3.12.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.1.tgz",
+      "integrity": "sha512-um46hB9wNOKlwkHgiuyEVAybXBjwFUV0Z/RaHJblRd9DXltue9FTYvzCr9ErQrK9Adz5MU4gHWVaNUfdmrC8qA==",
+      "dev": true,
+      "requires": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      }
+    },
+    "json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
+    },
+    "json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
     },
     "json3": {
@@ -142,11 +698,31 @@
       "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=",
       "dev": true
     },
+    "levn": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
+      }
+    },
+    "lodash": {
+      "version": "4.17.11",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+      "dev": true
+    },
     "lodash._baseassign": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
       "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash._basecopy": "^3.0.0",
+        "lodash.keys": "^3.0.0"
+      }
     },
     "lodash._basecopy": {
       "version": "3.0.1",
@@ -176,7 +752,12 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
       "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash._baseassign": "^3.0.0",
+        "lodash._basecreate": "^3.0.0",
+        "lodash._isiterateecall": "^3.0.0"
+      }
     },
     "lodash.isarguments": {
       "version": "3.1.0",
@@ -194,13 +775,27 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
       "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+      "dev": true,
+      "requires": {
+        "lodash._getnative": "^3.0.0",
+        "lodash.isarguments": "^3.0.0",
+        "lodash.isarray": "^3.0.0"
+      }
+    },
+    "mimic-fn": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
       "dev": true
     },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
     },
     "minimist": {
       "version": "0.0.8",
@@ -212,13 +807,29 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      }
     },
     "mocha": {
       "version": "3.4.2",
       "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.4.2.tgz",
       "integrity": "sha1-0O9NMyEm2/GNDWQMmzgt1IvpdZQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "browser-stdout": "1.3.0",
+        "commander": "2.9.0",
+        "debug": "2.6.0",
+        "diff": "3.2.0",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.1.1",
+        "growl": "1.9.2",
+        "json3": "3.3.2",
+        "lodash.create": "3.1.1",
+        "mkdirp": "0.5.1",
+        "supports-color": "3.1.2"
+      }
     },
     "ms": {
       "version": "0.7.2",
@@ -226,16 +837,93 @@
       "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U=",
       "dev": true
     },
+    "mute-stream": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+      "dev": true
+    },
+    "natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+      "dev": true
+    },
+    "nice-try": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+      "dev": true
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
+    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "onetime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+      "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+      "dev": true,
+      "requires": {
+        "mimic-fn": "^1.0.0"
+      }
+    },
+    "optionator": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+      "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+      "dev": true,
+      "requires": {
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.4",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "wordwrap": "~1.0.0"
+      }
+    },
+    "os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
+    },
+    "parent-module": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.0.tgz",
+      "integrity": "sha512-8Mf5juOMmiE4FcmzYc4IaiS9L3+9paz2KOiXzkRviCP6aDmN49Hz6EMWz0lGNp9pX80GvvAuLADtyGfW/Em3TA==",
+      "dev": true,
+      "requires": {
+        "callsites": "^3.0.0"
+      }
     },
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "path-is-inside": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+      "dev": true
+    },
+    "path-key": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
       "dev": true
     },
     "pathval": {
@@ -244,11 +932,226 @@
       "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
       "dev": true
     },
+    "pluralize": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
+      "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
+      "dev": true
+    },
+    "prelude-ls": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "dev": true
+    },
+    "progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true
+    },
+    "punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true
+    },
+    "regexpp": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
+      "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
+      "dev": true
+    },
+    "resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true
+    },
+    "restore-cursor": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+      "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+      "dev": true,
+      "requires": {
+        "onetime": "^2.0.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
+    "rimraf": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.1.3"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.1.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+          "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        }
+      }
+    },
+    "run-async": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
+      "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+      "dev": true,
+      "requires": {
+        "is-promise": "^2.1.0"
+      }
+    },
+    "rxjs": {
+      "version": "6.3.3",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.3.3.tgz",
+      "integrity": "sha512-JTWmoY9tWCs7zvIk/CvRjhjGaOd+OVBM987mxFo+OW66cGpdKjZcpmc74ES1sB//7Kl/PAe8+wEakuhG4pcgOw==",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.9.0"
+      }
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
+    },
+    "semver": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
+      "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
+      "dev": true
+    },
+    "shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "dev": true,
+      "requires": {
+        "shebang-regex": "^1.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+      "dev": true
+    },
+    "signal-exit": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+      "dev": true
+    },
+    "slice-ansi": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
+      "integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^3.2.0",
+        "astral-regex": "^1.0.0",
+        "is-fullwidth-code-point": "^2.0.0"
+      }
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
+    },
+    "string-width": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "dev": true,
+      "requires": {
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^4.0.0"
+      }
+    },
+    "strip-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^3.0.0"
+      }
+    },
+    "strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+      "dev": true
+    },
     "supports-color": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
       "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
+      "dev": true,
+      "requires": {
+        "has-flag": "^1.0.0"
+      }
+    },
+    "table": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/table/-/table-5.2.2.tgz",
+      "integrity": "sha512-f8mJmuu9beQEDkKHLzOv4VxVYlU68NpdzjbGPl69i4Hx0sTopJuNxuzJd17iV2h24dAfa93u794OnDA5jqXvfQ==",
+      "dev": true,
+      "requires": {
+        "ajv": "^6.6.1",
+        "lodash": "^4.17.11",
+        "slice-ansi": "^2.0.0",
+        "string-width": "^2.1.1"
+      }
+    },
+    "text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
+    },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "dev": true
+    },
+    "tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "dev": true,
+      "requires": {
+        "os-tmpdir": "~1.0.2"
+      }
+    },
+    "tslib": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
+      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
+      "dev": true
+    },
+    "type-check": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "~1.1.2"
+      }
     },
     "type-detect": {
       "version": "4.0.3",
@@ -256,11 +1159,44 @@
       "integrity": "sha1-Dj8mcLRAmbC0bChNE2p+9Jx0wuo=",
       "dev": true
     },
+    "uri-js": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+      "dev": true,
+      "requires": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
+      "requires": {
+        "isexe": "^2.0.0"
+      }
+    },
+    "wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+      "dev": true
+    },
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
+    },
+    "write": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
+      "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
+      "dev": true,
+      "requires": {
+        "mkdirp": "^0.5.1"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "example": "example"
   },
   "scripts": {
-    "test": "mocha --reporter spec"
+    "test": "mocha --reporter spec",
+    "lint": "eslint test"
   },
   "repository": {
     "type": "git",
@@ -58,6 +59,7 @@
   "_resolved": "http://registry.npmjs.org/color-contrast-checker/-/color-contrast-checker-1.2.0.tgz",
   "devDependencies": {
     "chai": "^4.1.0",
+    "eslint": "^5.12.1",
     "mocha": "^3.4.2"
   }
 }

--- a/src/color-contrast-checker.js
+++ b/src/color-contrast-checker.js
@@ -33,7 +33,7 @@ define(function () {
             }
         },
         isValidSixDigitColorCode: function (hex){
-            var regSixDigitColorcode = /^(#)?([0-9a-fA-F]{6})([0-9a-fA-F]{6})?$/;
+            var regSixDigitColorcode = /^(#)?([0-9a-fA-F]{6})?$/;
             return regSixDigitColorcode.test(hex);
         },
         isValidThreeDigitColorCode: function (hex){

--- a/src/color-contrast-checker.js
+++ b/src/color-contrast-checker.js
@@ -39,11 +39,14 @@ define(function (require, exports, module) {
             return regSixDigitColorcode.test(hex);
         },
         isValidThreeDigitColorCode: function (hex){
-            var regThreeDigitColorcode = /^(#)?([0-9a-fA-F]{3})([0-9a-fA-F]{3})?$/;
+            var regThreeDigitColorcode = /^(#)?([0-9a-fA-F]{3})?$/;
             return regThreeDigitColorcode.test(hex);
         },
         isValidColorCode : function (hex){
             return this.isValidSixDigitColorCode(hex) || this.isValidThreeDigitColorCode(hex);
+        },
+        isValidRatio : function (ratio){
+            return (typeof ratio === 'number')
         },
         convertColorToSixDigit: function (hex) {
           return '#' + hex[1] + hex[1] + hex[2] + hex[2] + hex[3] + hex[3];
@@ -77,6 +80,9 @@ define(function (require, exports, module) {
             var contrastRatio = this.getContrastRatio(l1, l2);
 
             if (typeof customRatio !== 'undefined') {
+                if (!this.isValidRatio(customRatio)) {
+                    return false;
+                }
                 return this.verifyCustomContrastRatio(contrastRatio, customRatio);
             } else {
                 return this.verifyContrastRatio(contrastRatio);
@@ -122,7 +128,8 @@ define(function (require, exports, module) {
             return result.WCAG_AAA; 
         },
         isLevelCustom : function(colorA, colorB, ratio) {
-            
+            var result = this.check(colorA, colorB, void 0, ratio);
+            return result.customRatio;
         },
         getRGBFromHex : function(color) {
 
@@ -234,7 +241,6 @@ define(function (require, exports, module) {
             var results = Object.create(resultsClass)
 
             results.customRatio = (inputRatio >= checkRatio);
-
             return results;
         }
 

--- a/src/color-contrast-checker.js
+++ b/src/color-contrast-checker.js
@@ -1,4 +1,4 @@
-'use strict';
+"use strict";
 
 /**
  * Color Contast Checker
@@ -15,12 +15,10 @@
  * }
  */
 
-var amdefine = false;
-if (typeof define !== 'function')
-    var define = require('amdefine')(module, require),
-        amdefine = true;
+if (typeof define !== "function")
+    var define = require("amdefine")(module, require);
 
-define(function (require, exports, module) {
+define(function () {
 
     var ColorContrastChecker = function() {};
 
@@ -28,10 +26,10 @@ define(function (require, exports, module) {
         fontSize: 14,
         rgbClass : {
             toString: function() {
-                return '<r: ' + this.r +
-                    ' g: ' + this.g +
-                    ' b: ' + this.b +
-                    ' >';
+                return "<r: " + this.r +
+                    " g: " + this.g +
+                    " b: " + this.b +
+                    " >";
             }
         },
         isValidSixDigitColorCode: function (hex){
@@ -46,10 +44,10 @@ define(function (require, exports, module) {
             return this.isValidSixDigitColorCode(hex) || this.isValidThreeDigitColorCode(hex);
         },
         isValidRatio : function (ratio){
-            return (typeof ratio === 'number')
+            return (typeof ratio === "number");
         },
         convertColorToSixDigit: function (hex) {
-          return '#' + hex[1] + hex[1] + hex[2] + hex[2] + hex[3] + hex[3];
+            return "#" + hex[1] + hex[1] + hex[2] + hex[2] + hex[3] + hex[3];
         },
         hexToLuminance: function (color) {
             if (!this.isValidColorCode(color)) {
@@ -57,7 +55,7 @@ define(function (require, exports, module) {
             }
 
             if (this.isValidThreeDigitColorCode(color)) {
-              color = this.convertColorToSixDigit(color);
+                color = this.convertColorToSixDigit(color);
             }
 
             color = this.getRGBFromHex(color);
@@ -67,7 +65,7 @@ define(function (require, exports, module) {
             return this.calculateLuminance(LRGB);
         },
         check: function (colorA, colorB, fontSize, customRatio) {
-            if (typeof fontSize !== 'undefined') {
+            if (typeof fontSize !== "undefined") {
                 this.fontSize = fontSize;
             }
 
@@ -79,7 +77,7 @@ define(function (require, exports, module) {
             var l2 = this.hexToLuminance(colorB); /* lower value */
             var contrastRatio = this.getContrastRatio(l1, l2);
 
-            if (typeof customRatio !== 'undefined') {
+            if (typeof customRatio !== "undefined") {
                 if (!this.isValidRatio(customRatio)) {
                     return false;
                 }
@@ -94,7 +92,7 @@ define(function (require, exports, module) {
 
             for (var i in pairs) {
                 var pair = pairs[i];
-                if (typeof pair.fontSize !== 'undefined') {
+                if (typeof pair.fontSize !== "undefined") {
                     results.push(
                         this.check(
                             pair.colorA,
@@ -138,8 +136,8 @@ define(function (require, exports, module) {
                 gVal,
                 bVal;
 
-            if (typeof color !== 'string') {
-                throw new Error('must use string');
+            if (typeof color !== "string") {
+                throw new Error("must use string");
             }
 
             rVal = parseInt(color.slice(1, 3), 16);
@@ -205,9 +203,9 @@ define(function (require, exports, module) {
 
             var resultsClass = {
                 toString: function() {
-                    return '< WCAG-AA: ' + ((this.WCAG_AA) ? 'pass' : 'fail') +
-                        ' WCAG-AAA: ' + ((this.WCAG_AAA) ? 'pass' : 'fail') +
-                        ' >';
+                    return "< WCAG-AA: " + ((this.WCAG_AA) ? "pass" : "fail") +
+                        " WCAG-AAA: " + ((this.WCAG_AAA) ? "pass" : "fail") +
+                        " >";
                 }
             };
             var WCAG_REQ_RATIO_AA_LG = 3.0,
@@ -233,12 +231,12 @@ define(function (require, exports, module) {
 
             var resultsClass = {
                 toString: function() {
-                    return '< Custom Ratio: ' + ((this.customRatio) ? 'pass' : 'fail') +
-                        '  >';
+                    return "< Custom Ratio: " + ((this.customRatio) ? "pass" : "fail") +
+                        "  >";
                 }
             };
 
-            var results = Object.create(resultsClass)
+            var results = Object.create(resultsClass);
 
             results.customRatio = (inputRatio >= checkRatio);
             return results;

--- a/src/color-contrast-checker.js
+++ b/src/color-contrast-checker.js
@@ -63,7 +63,7 @@ define(function (require, exports, module) {
 
             return this.calculateLuminance(LRGB);
         },
-        check: function (colorA, colorB, fontSize) {
+        check: function (colorA, colorB, fontSize, customRatio) {
             if (typeof fontSize !== 'undefined') {
                 this.fontSize = fontSize;
             }
@@ -76,9 +76,14 @@ define(function (require, exports, module) {
             var l2 = this.hexToLuminance(colorB); /* lower value */
             var contrastRatio = this.getContrastRatio(l1, l2);
 
-            return this.verifyContrastRatio(contrastRatio);
+            if (typeof customRatio !== 'undefined') {
+                return this.verifyCustomContrastRatio(contrastRatio, customRatio);
+            } else {
+                return this.verifyContrastRatio(contrastRatio);
+            }
+            
         },
-        checkPairs: function (pairs) {
+        checkPairs: function (pairs, customRatio) {
             var results = [];
 
             for (var i in pairs) {
@@ -88,14 +93,17 @@ define(function (require, exports, module) {
                         this.check(
                             pair.colorA,
                             pair.colorB,
-                            pair.fontSize
+                            pair.fontSize,
+                            customRatio
                         )
                     );
                 } else {
                     results.push(
                         this.check(
                             pair.colorA,
-                            pair.colorB
+                            pair.colorB,
+                            void 0,
+                            customRatio
                         )
                     );
                 }
@@ -111,7 +119,10 @@ define(function (require, exports, module) {
         },
         isLevelAAA : function(colorA, colorB, fontSize) {
             var result = this.check(colorA, colorB, fontSize);
-            return result.WCAG_AAA;
+            return result.WCAG_AAA; 
+        },
+        isLevelCustom : function(colorA, colorB, ratio) {
+            
         },
         getRGBFromHex : function(color) {
 
@@ -208,6 +219,21 @@ define(function (require, exports, module) {
                 results.WCAG_AA = (ratio >= WCAG_REQ_RATIO_AA_SM);
                 results.WCAG_AAA = (ratio >= WCAG_REQ_RATIO_AAA_SM);
             }
+
+            return results;
+        },
+        verifyCustomContrastRatio : function(inputRatio, checkRatio) {
+
+            var resultsClass = {
+                toString: function() {
+                    return '< Custom Ratio: ' + ((this.customRatio) ? 'pass' : 'fail') +
+                        '  >';
+                }
+            };
+
+            var results = Object.create(resultsClass)
+
+            results.customRatio = (inputRatio >= checkRatio);
 
             return results;
         }

--- a/test/color-contrast-checker.js
+++ b/test/color-contrast-checker.js
@@ -19,6 +19,11 @@ describe('Three Digit Color Code Lengths', function() {
     var result = ccc.isValidThreeDigitColorCode("#FFFF");
     expect(result).to.be.false;
   });
+
+  it('should reject 6 digit color code', function() {
+    var result = ccc.isValidThreeDigitColorCode("#FFFFFF");
+    expect(result).to.be.false;
+  });
 });
 
 describe('Six Digit Color Code Lengths', function() {
@@ -34,6 +39,11 @@ describe('Six Digit Color Code Lengths', function() {
 
   it('should reject 7 digit color code', function() {
     var result = ccc.isValidSixDigitColorCode("#FFFFFFF");
+    expect(result).to.be.false;
+  });
+
+  it('should reject 3 digit color code', function() {
+    var result = ccc.isValidSixDigitColorCode("#FFF");
     expect(result).to.be.false;
   });
 });
@@ -92,12 +102,12 @@ describe('Convert Hex to Luminance', function() {
 
   it('should convert blue color luminance value', function() {
     var result = ccc.hexToLuminance("#0000FF");
-    expect(result).to.equal(0);
+    expect(result).to.equal(0.0722);
   });
 
    it('should convert yellow color luminance value', function() {
     var result = ccc.hexToLuminance("#ffff00");
-    expect(result).to.equal(1);
+    expect(result).to.equal(0.9278);
   });
 });
 
@@ -137,17 +147,17 @@ describe('Basic Validation for LevelAAA', function() {
 
 describe('Basic Validation for Custom Ratio', function() {
   it('should return true when contrast is valid for three digit color codes', function() {
-   var result = ccc.isLevelCustom("#FFF", "#000", 14, 5);
+   var result = ccc.isLevelCustom("#FFF", "#000", 5);
    expect(result).to.be.true;
  });
 
  it('should return true when contrast is valid', function() {
-   var result = ccc.isLevelCustom("#FFFFFF", "#000000", 14, 5);
+   var result = ccc.isLevelCustom("#FFFFFF", "#000000", 5);
    expect(result).to.be.true;
  });
 
  it('should return false when contrast is invalid', function() {
-   var result = ccc.isLevelCustom("#000000", "#000000", 14, 5);
+   var result = ccc.isLevelCustom("#000000", "#000000", 5);
    expect(result).to.be.false;
  });
 });
@@ -210,7 +220,6 @@ describe('Six Digit Pair Validation for LevelAAA', function() {
 
   it('should return the expectedResults for checkPairs', function() {
     var results = ccc.checkPairs(pairs);
-    console.log(results, "\n", expectedResults);
     expect(results).to.be.an('array');
     expect(results).to.have.lengthOf(6);
     expect(objectsAreSame(results, expectedResults)).to.be.true;

--- a/test/color-contrast-checker.js
+++ b/test/color-contrast-checker.js
@@ -1,342 +1,342 @@
-'use strict';
+"use strict";
 
-var expect  = require('chai').expect;
-var ColorContrastChecker = require('../src/color-contrast-checker');
+var expect  = require("chai").expect;
+var ColorContrastChecker = require("../src/color-contrast-checker");
 var ccc = new ColorContrastChecker();
 
-describe('Three Digit Color Code Lengths', function() {
-  it('should accept 3 digit color code', function() {
-    var result = ccc.isValidThreeDigitColorCode("#FFF");
-    expect(result).to.be.true;
-  });
+describe("Three Digit Color Code Lengths", function() {
+    it("should accept 3 digit color code", function() {
+        var result = ccc.isValidThreeDigitColorCode("#FFF");
+        expect(result).to.be.true;
+    });
 
-  it('should reject 2 digit color code', function() {
-    var result = ccc.isValidThreeDigitColorCode("#FF");
-    expect(result).to.be.false;
-  });
+    it("should reject 2 digit color code", function() {
+        var result = ccc.isValidThreeDigitColorCode("#FF");
+        expect(result).to.be.false;
+    });
 
-  it('should reject 4 digit color code', function() {
-    var result = ccc.isValidThreeDigitColorCode("#FFFF");
-    expect(result).to.be.false;
-  });
+    it("should reject 4 digit color code", function() {
+        var result = ccc.isValidThreeDigitColorCode("#FFFF");
+        expect(result).to.be.false;
+    });
 
-  it('should reject 6 digit color code', function() {
-    var result = ccc.isValidThreeDigitColorCode("#FFFFFF");
-    expect(result).to.be.false;
-  });
+    it("should reject 6 digit color code", function() {
+        var result = ccc.isValidThreeDigitColorCode("#FFFFFF");
+        expect(result).to.be.false;
+    });
 });
 
-describe('Six Digit Color Code Lengths', function() {
-  it('should accept 6 digit color code', function() {
-    var result = ccc.isValidSixDigitColorCode("#FFFFFF");
-    expect(result).to.be.true;
-  });
+describe("Six Digit Color Code Lengths", function() {
+    it("should accept 6 digit color code", function() {
+        var result = ccc.isValidSixDigitColorCode("#FFFFFF");
+        expect(result).to.be.true;
+    });
 
-  it('should reject 5 digit color code', function() {
-    var result = ccc.isValidSixDigitColorCode("#FFFFF");
-    expect(result).to.be.false;
-  });
+    it("should reject 5 digit color code", function() {
+        var result = ccc.isValidSixDigitColorCode("#FFFFF");
+        expect(result).to.be.false;
+    });
 
-  it('should reject 7 digit color code', function() {
-    var result = ccc.isValidSixDigitColorCode("#FFFFFFF");
-    expect(result).to.be.false;
-  });
+    it("should reject 7 digit color code", function() {
+        var result = ccc.isValidSixDigitColorCode("#FFFFFFF");
+        expect(result).to.be.false;
+    });
 
-  it('should reject 3 digit color code', function() {
-    var result = ccc.isValidSixDigitColorCode("#FFF");
-    expect(result).to.be.false;
-  });
+    it("should reject 3 digit color code", function() {
+        var result = ccc.isValidSixDigitColorCode("#FFF");
+        expect(result).to.be.false;
+    });
 });
 
-describe('Supported Color Code Lengths', function() {
-  it('should accept 3 digit color code', function() {
-    var result = ccc.isValidColorCode("#FFF");
-    expect(result).to.be.true;
-  });
+describe("Supported Color Code Lengths", function() {
+    it("should accept 3 digit color code", function() {
+        var result = ccc.isValidColorCode("#FFF");
+        expect(result).to.be.true;
+    });
 
-  it('should accept 6 digit color code', function() {
-    var result = ccc.isValidColorCode("#FFFFFF");
-    expect(result).to.be.true;
-  });
+    it("should accept 6 digit color code", function() {
+        var result = ccc.isValidColorCode("#FFFFFF");
+        expect(result).to.be.true;
+    });
 
-  it('should reject 7 digit color code', function() {
-    var result = ccc.isValidColorCode("#FFFFFFF");
-    expect(result).to.be.false;
-  });
+    it("should reject 7 digit color code", function() {
+        var result = ccc.isValidColorCode("#FFFFFFF");
+        expect(result).to.be.false;
+    });
 });
 
-describe('Supported Custom Ratio Inputs', function() {
-  it('should accept an integer', function() {
-    var result = ccc.isValidRatio(1);
-    expect(result).to.be.true;
-  });
+describe("Supported Custom Ratio Inputs", function() {
+    it("should accept an integer", function() {
+        var result = ccc.isValidRatio(1);
+        expect(result).to.be.true;
+    });
 
-  it('should accept a float', function() {
-    var result = ccc.isValidRatio(3.2);
-    expect(result).to.be.true;
-  });
+    it("should accept a float", function() {
+        var result = ccc.isValidRatio(3.2);
+        expect(result).to.be.true;
+    });
 
-  it('should reject a string', function() {
-    var result = ccc.isValidRatio("3.2");
-    expect(result).to.be.false;
-  });
+    it("should reject a string", function() {
+        var result = ccc.isValidRatio("3.2");
+        expect(result).to.be.false;
+    });
 });
 
-describe('Convert Color from 3 digit to 6 digit', function() {
-  it('should convert 3 digit color to 6 digit', function() {
-    var result = ccc.convertColorToSixDigit("#FFF");
-    expect(result).to.equal("#FFFFFF");
-  });
+describe("Convert Color from 3 digit to 6 digit", function() {
+    it("should convert 3 digit color to 6 digit", function() {
+        var result = ccc.convertColorToSixDigit("#FFF");
+        expect(result).to.equal("#FFFFFF");
+    });
 });
 
-describe('Convert Hex to Luminance', function() {
-  it('should convert 3 digit color luminance value', function() {
-    var result = ccc.hexToLuminance("#FFF");
-    expect(result).to.equal(1);
-  });
+describe("Convert Hex to Luminance", function() {
+    it("should convert 3 digit color luminance value", function() {
+        var result = ccc.hexToLuminance("#FFF");
+        expect(result).to.equal(1);
+    });
   
-  it('should convert 6 digit color luminance value', function() {
-    var result = ccc.hexToLuminance("#FFFFFF");
-    expect(result).to.equal(1);
-  });
-
-  it('should convert blue color luminance value', function() {
-    var result = ccc.hexToLuminance("#0000FF");
-    expect(result).to.equal(0.0722);
-  });
-
-   it('should convert yellow color luminance value', function() {
-    var result = ccc.hexToLuminance("#ffff00");
-    expect(result).to.equal(0.9278);
-  });
-});
-
-describe('Basic Validation for LevelAA', function() {
-   it('should return true when contrast is valid for three digit color codes', function() {
-    var result = ccc.isLevelAA("#FFF", "#000", 14);
-    expect(result).to.be.true;
-  });
-
-  it('should return true when contrast is valid', function() {
-    var result = ccc.isLevelAA("#FFFFFF", "#000000", 14);
-    expect(result).to.be.true;
-  });
-
-  it('should return false when contrast is invalid', function() {
-    var result = ccc.isLevelAA("#000000", "#000000", 14);
-    expect(result).to.be.false;
-  });
-});
-
-describe('Basic Validation for LevelAAA', function() {
-   it('should return true when contrast is valid for three digit color codes', function() {
-    var result = ccc.isLevelAA("#FFF", "#000", 14);
-    expect(result).to.be.true;
-  });
-
-  it('should return true when contrast is valid', function() {
-    var result = ccc.isLevelAA("#FFFFFF", "#000000", 14);
-    expect(result).to.be.true;
-  });
-
-  it('should return false when contrast is invalid', function() {
-    var result = ccc.isLevelAA("#000000", "#000000", 14);
-    expect(result).to.be.false;
-  });
-});
-
-describe('Basic Validation for Custom Ratio', function() {
-  it('should return true when contrast is valid for three digit color codes', function() {
-   var result = ccc.isLevelCustom("#FFF", "#000", 5);
-   expect(result).to.be.true;
- });
-
- it('should return true when contrast is valid', function() {
-   var result = ccc.isLevelCustom("#FFFFFF", "#000000", 5);
-   expect(result).to.be.true;
- });
-
- it('should return false when contrast is invalid', function() {
-   var result = ccc.isLevelCustom("#000000", "#000000", 5);
-   expect(result).to.be.false;
- });
-});
-
-describe('Six Digit Pair Validation for LevelAAA', function() {
-  var pairs = [
-      {
-          'colorA': '#000000',
-          'colorB': '#000000',  // All should fail
-          'fontSize': 14
-      },
-      {
-          'colorA': '#000000',
-          'colorB': '#FFFFFF',  //All should pass
-          'fontSize': 14
-      },
-      {
-          'colorA': '#000000',
-          'colorB': '#998899',  //AAA should fail
-          'fontSize': 14
-      },
-      {
-          'colorA': '#000000',
-          'colorB': '#998899',  //All should pass (because of font)
-          'fontSize': 19
-      },
-      {
-          'colorA': '#000000',
-          'colorB': '#887788',  //AA should pass AAA should fail
-          'fontSize': 14
-      },
-      {
-          'colorA': '#000000',
-          'colorB': '#656565',  //All should fail
-          'fontSize': 14
-      }
-  ];
-
-
-  var expectedResults = [ 
-    { WCAG_AA: false, WCAG_AAA: false },
-    { WCAG_AA: true, WCAG_AAA: true },
-    { WCAG_AA: true, WCAG_AAA: false },
-    { WCAG_AA: true, WCAG_AAA: true },
-    { WCAG_AA: true, WCAG_AAA: false },
-    { WCAG_AA: false, WCAG_AAA: false } ];
-
-  function objectsAreSame(x, y) {
-    var objectsAreSame = true;
-    x.forEach((element, index) => {
-      if (element.WCAG_AA !== y[index].WCAG_AA) {
-        objectsAreSame = false
-      }
-      if (element.WCAG_AAA !== y[index].WCAG_AAA) {
-        objectsAreSame = false
-      }
+    it("should convert 6 digit color luminance value", function() {
+        var result = ccc.hexToLuminance("#FFFFFF");
+        expect(result).to.equal(1);
     });
-    return objectsAreSame;
-    }
 
-  it('should return the expectedResults for checkPairs', function() {
-    var results = ccc.checkPairs(pairs);
-    expect(results).to.be.an('array');
-    expect(results).to.have.lengthOf(6);
-    expect(objectsAreSame(results, expectedResults)).to.be.true;
-  }); 
-});
-
-describe('Three Digit Pair Validation for LevelAAA', function() {
-  var pairs = [
-      {
-          'colorA': '#000',
-          'colorB': '#000',  // All should fail
-          'fontSize': 14
-      },
-      {
-          'colorA': '#000',
-          'colorB': '#FFF',  //All should pass
-          'fontSize': 14
-      },
-      {
-          'colorA': '#000',
-          'colorB': '#989',  //AAA should fail
-          'fontSize': 14
-      },
-      {
-          'colorA': '#000',
-          'colorB': '#989',  //All should pass (because of font)
-          'fontSize': 19
-      },
-      {
-          'colorA': '#000',
-          'colorB': '#878',  //AA should pass AAA should fail
-          'fontSize': 14
-      },
-      {
-          'colorA': '#000',
-          'colorB': '#656',  //All should fail
-          'fontSize': 14
-      }
-  ];
-
-
-  var expectedResults = [ 
-    { WCAG_AA: false, WCAG_AAA: false },
-    { WCAG_AA: true, WCAG_AAA: true },
-    { WCAG_AA: true, WCAG_AAA: false },
-    { WCAG_AA: true, WCAG_AAA: true },
-    { WCAG_AA: true, WCAG_AAA: false },
-    { WCAG_AA: false, WCAG_AAA: false } ];
-
-  function objectsAreSame(x, y) {
-    var objectsAreSame = true;
-    x.forEach((element, index) => {
-      if (element.WCAG_AA !== y[index].WCAG_AA) {
-        objectsAreSame = false
-      }
-      if (element.WCAG_AAA !== y[index].WCAG_AAA) {
-        objectsAreSame = false
-      }
+    it("should convert blue color luminance value", function() {
+        var result = ccc.hexToLuminance("#0000FF");
+        expect(result).to.equal(0.0722);
     });
-    return objectsAreSame;
-   }
-  it('should return the expectedResults for checkPairs', function() {
-    var results = ccc.checkPairs(pairs);
-    expect(results).to.be.an('array');
-    expect(results).to.have.lengthOf(6);
-    expect(objectsAreSame(results, expectedResults)).to.be.true;
-  }); 
+
+    it("should convert yellow color luminance value", function() {
+        var result = ccc.hexToLuminance("#ffff00");
+        expect(result).to.equal(0.9278);
+    });
 });
 
-  describe('Six Digit Pair Validation for Custom Ratio', function() {
+describe("Basic Validation for LevelAA", function() {
+    it("should return true when contrast is valid for three digit color codes", function() {
+        var result = ccc.isLevelAA("#FFF", "#000", 14);
+        expect(result).to.be.true;
+    });
+
+    it("should return true when contrast is valid", function() {
+        var result = ccc.isLevelAA("#FFFFFF", "#000000", 14);
+        expect(result).to.be.true;
+    });
+
+    it("should return false when contrast is invalid", function() {
+        var result = ccc.isLevelAA("#000000", "#000000", 14);
+        expect(result).to.be.false;
+    });
+});
+
+describe("Basic Validation for LevelAAA", function() {
+    it("should return true when contrast is valid for three digit color codes", function() {
+        var result = ccc.isLevelAA("#FFF", "#000", 14);
+        expect(result).to.be.true;
+    });
+
+    it("should return true when contrast is valid", function() {
+        var result = ccc.isLevelAA("#FFFFFF", "#000000", 14);
+        expect(result).to.be.true;
+    });
+
+    it("should return false when contrast is invalid", function() {
+        var result = ccc.isLevelAA("#000000", "#000000", 14);
+        expect(result).to.be.false;
+    });
+});
+
+describe("Basic Validation for Custom Ratio", function() {
+    it("should return true when contrast is valid for three digit color codes", function() {
+        var result = ccc.isLevelCustom("#FFF", "#000", 5);
+        expect(result).to.be.true;
+    });
+
+    it("should return true when contrast is valid", function() {
+        var result = ccc.isLevelCustom("#FFFFFF", "#000000", 5);
+        expect(result).to.be.true;
+    });
+
+    it("should return false when contrast is invalid", function() {
+        var result = ccc.isLevelCustom("#000000", "#000000", 5);
+        expect(result).to.be.false;
+    });
+});
+
+describe("Six Digit Pair Validation for LevelAAA", function() {
     var pairs = [
         {
-            'colorA': '#000000',
-            'colorB': '#000000',  // This should fail
-            'fontSize': 14
+            "colorA": "#000000",
+            "colorB": "#000000",  // All should fail
+            "fontSize": 14
         },
         {
-            'colorA': '#000000',
-            'colorB': '#FFFFFF',  // This should pass
-            'fontSize': 14
+            "colorA": "#000000",
+            "colorB": "#FFFFFF",  //All should pass
+            "fontSize": 14
         },
         {
-            'colorA': '#000000',
-            'colorB': '#998899',  // This should pass
-            'fontSize': 14
+            "colorA": "#000000",
+            "colorB": "#998899",  //AAA should fail
+            "fontSize": 14
         },
         {
-            'colorA': '#000000',
-            'colorB': '#656565',  // This should fail
-            'fontSize': 14
+            "colorA": "#000000",
+            "colorB": "#998899",  //All should pass (because of font)
+            "fontSize": 19
+        },
+        {
+            "colorA": "#000000",
+            "colorB": "#887788",  //AA should pass AAA should fail
+            "fontSize": 14
+        },
+        {
+            "colorA": "#000000",
+            "colorB": "#656565",  //All should fail
+            "fontSize": 14
+        }
+    ];
+
+
+    var expectedResults = [ 
+        { WCAG_AA: false, WCAG_AAA: false },
+        { WCAG_AA: true, WCAG_AAA: true },
+        { WCAG_AA: true, WCAG_AAA: false },
+        { WCAG_AA: true, WCAG_AAA: true },
+        { WCAG_AA: true, WCAG_AAA: false },
+        { WCAG_AA: false, WCAG_AAA: false } ];
+
+    function objectsAreSame(x, y) {
+        var objectsAreSame = true;
+        x.forEach((element, index) => {
+            if (element.WCAG_AA !== y[index].WCAG_AA) {
+                objectsAreSame = false;
+            }
+            if (element.WCAG_AAA !== y[index].WCAG_AAA) {
+                objectsAreSame = false;
+            }
+        });
+        return objectsAreSame;
+    }
+
+    it("should return the expectedResults for checkPairs", function() {
+        var results = ccc.checkPairs(pairs);
+        expect(results).to.be.an("array");
+        expect(results).to.have.lengthOf(6);
+        expect(objectsAreSame(results, expectedResults)).to.be.true;
+    }); 
+});
+
+describe("Three Digit Pair Validation for LevelAAA", function() {
+    var pairs = [
+        {
+            "colorA": "#000",
+            "colorB": "#000",  // All should fail
+            "fontSize": 14
+        },
+        {
+            "colorA": "#000",
+            "colorB": "#FFF",  //All should pass
+            "fontSize": 14
+        },
+        {
+            "colorA": "#000",
+            "colorB": "#989",  //AAA should fail
+            "fontSize": 14
+        },
+        {
+            "colorA": "#000",
+            "colorB": "#989",  //All should pass (because of font)
+            "fontSize": 19
+        },
+        {
+            "colorA": "#000",
+            "colorB": "#878",  //AA should pass AAA should fail
+            "fontSize": 14
+        },
+        {
+            "colorA": "#000",
+            "colorB": "#656",  //All should fail
+            "fontSize": 14
+        }
+    ];
+
+
+    var expectedResults = [ 
+        { WCAG_AA: false, WCAG_AAA: false },
+        { WCAG_AA: true, WCAG_AAA: true },
+        { WCAG_AA: true, WCAG_AAA: false },
+        { WCAG_AA: true, WCAG_AAA: true },
+        { WCAG_AA: true, WCAG_AAA: false },
+        { WCAG_AA: false, WCAG_AAA: false } ];
+
+    function objectsAreSame(x, y) {
+        var objectsAreSame = true;
+        x.forEach((element, index) => {
+            if (element.WCAG_AA !== y[index].WCAG_AA) {
+                objectsAreSame = false;
+            }
+            if (element.WCAG_AAA !== y[index].WCAG_AAA) {
+                objectsAreSame = false;
+            }
+        });
+        return objectsAreSame;
+    }
+    it("should return the expectedResults for checkPairs", function() {
+        var results = ccc.checkPairs(pairs);
+        expect(results).to.be.an("array");
+        expect(results).to.have.lengthOf(6);
+        expect(objectsAreSame(results, expectedResults)).to.be.true;
+    }); 
+});
+
+describe("Six Digit Pair Validation for Custom Ratio", function() {
+    var pairs = [
+        {
+            "colorA": "#000000",
+            "colorB": "#000000",  // This should fail
+            "fontSize": 14
+        },
+        {
+            "colorA": "#000000",
+            "colorB": "#FFFFFF",  // This should pass
+            "fontSize": 14
+        },
+        {
+            "colorA": "#000000",
+            "colorB": "#998899",  // This should pass
+            "fontSize": 14
+        },
+        {
+            "colorA": "#000000",
+            "colorB": "#656565",  // This should fail
+            "fontSize": 14
         }
     ];
   
   
     var expectedResults = [ 
-      { customRatio: false },
-      { customRatio: true },
-      { customRatio: true },
-      { customRatio: false } ];
+        { customRatio: false },
+        { customRatio: true },
+        { customRatio: true },
+        { customRatio: false } ];
   
     function objectsAreSame(x, y) {
-      var objectsAreSame = true;
-      x.forEach((element, index) => {
-        if (element.WCAG_AA !== y[index].WCAG_AA) {
-          objectsAreSame = false
-        }
-        if (element.WCAG_AAA !== y[index].WCAG_AAA) {
-          objectsAreSame = false
-        }
-      });
-      return objectsAreSame;
+        var objectsAreSame = true;
+        x.forEach((element, index) => {
+            if (element.WCAG_AA !== y[index].WCAG_AA) {
+                objectsAreSame = false;
+            }
+            if (element.WCAG_AAA !== y[index].WCAG_AAA) {
+                objectsAreSame = false;
+            }
+        });
+        return objectsAreSame;
     }
 
-  it('should return the expectedResults for checkPairs', function() {
-    var results = ccc.checkPairs(pairs, 5.6);
-    expect(results).to.be.an('array');
-    expect(results).to.have.lengthOf(4);
-    expect(objectsAreSame(results, expectedResults)).to.be.true;
-  }); 
+    it("should return the expectedResults for checkPairs", function() {
+        var results = ccc.checkPairs(pairs, 5.6);
+        expect(results).to.be.an("array");
+        expect(results).to.have.lengthOf(4);
+        expect(objectsAreSame(results, expectedResults)).to.be.true;
+    }); 
 });

--- a/test/color-contrast-checker.js
+++ b/test/color-contrast-checker.js
@@ -196,16 +196,17 @@ describe('Six Digit Pair Validation for LevelAAA', function() {
     { WCAG_AA: false, WCAG_AAA: false } ];
 
   function objectsAreSame(x, y) {
-     var objectsAreSame = true;
-     for(var propertyName in x) {
-        if(x[propertyName].WCAG_AA !== y[propertyName].WCAG_AA
-           && x[propertyName].WCAG_AAA !== y[propertyName].WCAG_AAA) {
-           objectsAreSame = false;
-           break;
-        }
-     }
-     return objectsAreSame;
-  }
+    var objectsAreSame = true;
+    x.forEach((element, index) => {
+      if (element.WCAG_AA !== y[index].WCAG_AA) {
+        objectsAreSame = false
+      }
+      if (element.WCAG_AAA !== y[index].WCAG_AAA) {
+        objectsAreSame = false
+      }
+    });
+    return objectsAreSame;
+    }
 
   it('should return the expectedResults for checkPairs', function() {
     var results = ccc.checkPairs(pairs);
@@ -259,16 +260,17 @@ describe('Three Digit Pair Validation for LevelAAA', function() {
     { WCAG_AA: false, WCAG_AAA: false } ];
 
   function objectsAreSame(x, y) {
-     var objectsAreSame = true;
-     for(var propertyName in x) {
-        if(x[propertyName].WCAG_AA !== y[propertyName].WCAG_AA
-           && x[propertyName].WCAG_AAA !== y[propertyName].WCAG_AAA) {
-           objectsAreSame = false;
-           break;
-        }
-     }
-     return objectsAreSame;
-  }
+    var objectsAreSame = true;
+    x.forEach((element, index) => {
+      if (element.WCAG_AA !== y[index].WCAG_AA) {
+        objectsAreSame = false
+      }
+      if (element.WCAG_AAA !== y[index].WCAG_AAA) {
+        objectsAreSame = false
+      }
+    });
+    return objectsAreSame;
+   }
   it('should return the expectedResults for checkPairs', function() {
     var results = ccc.checkPairs(pairs);
     expect(results).to.be.an('array');
@@ -305,18 +307,20 @@ describe('Three Digit Pair Validation for LevelAAA', function() {
     var expectedResults = [ 
       { customRatio: false },
       { customRatio: true },
-      { customRatio: false },
+      { customRatio: true },
       { customRatio: false } ];
   
     function objectsAreSame(x, y) {
-       var objectsAreSame = true;
-       for(var propertyName in x) {
-          if(x[propertyName].customRatio !== y[propertyName].customRatio) {
-             objectsAreSame = false;
-             break;
-          }
-       }
-       return objectsAreSame;
+      var objectsAreSame = true;
+      x.forEach((element, index) => {
+        if (element.WCAG_AA !== y[index].WCAG_AA) {
+          objectsAreSame = false
+        }
+        if (element.WCAG_AAA !== y[index].WCAG_AAA) {
+          objectsAreSame = false
+        }
+      });
+      return objectsAreSame;
     }
 
   it('should return the expectedResults for checkPairs', function() {

--- a/test/color-contrast-checker.js
+++ b/test/color-contrast-checker.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var expect  = require('chai').expect;
-var ColorContrastChecker = require('color-contrast-checker');
+var ColorContrastChecker = require('../src/color-contrast-checker');
 var ccc = new ColorContrastChecker();
 
 describe('Three Digit Color Code Lengths', function() {

--- a/test/color-contrast-checker.js
+++ b/test/color-contrast-checker.js
@@ -166,17 +166,17 @@ describe('Six Digit Pair Validation for LevelAAA', function() {
       },
       {
           'colorA': '#000000',
-          'colorB': '#848484',  //AAA should fail
+          'colorB': '#998899',  //AAA should fail
           'fontSize': 14
       },
       {
           'colorA': '#000000',
-          'colorB': '#848484',  //All should pass (because of font)
+          'colorB': '#998899',  //All should pass (because of font)
           'fontSize': 19
       },
       {
           'colorA': '#000000',
-          'colorB': '#757575',  //AA should pass AAA should fail
+          'colorB': '#887788',  //AA should pass AAA should fail
           'fontSize': 14
       },
       {
@@ -210,6 +210,7 @@ describe('Six Digit Pair Validation for LevelAAA', function() {
 
   it('should return the expectedResults for checkPairs', function() {
     var results = ccc.checkPairs(pairs);
+    console.log(results, "\n", expectedResults);
     expect(results).to.be.an('array');
     expect(results).to.have.lengthOf(6);
     expect(objectsAreSame(results, expectedResults)).to.be.true;
@@ -230,17 +231,17 @@ describe('Three Digit Pair Validation for LevelAAA', function() {
       },
       {
           'colorA': '#000',
-          'colorB': '#848',  //AAA should fail
+          'colorB': '#989',  //AAA should fail
           'fontSize': 14
       },
       {
           'colorA': '#000',
-          'colorB': '#848',  //All should pass (because of font)
+          'colorB': '#989',  //All should pass (because of font)
           'fontSize': 19
       },
       {
           'colorA': '#000',
-          'colorB': '#757',  //AA should pass AAA should fail
+          'colorB': '#878',  //AA should pass AAA should fail
           'fontSize': 14
       },
       {
@@ -293,7 +294,7 @@ describe('Three Digit Pair Validation for LevelAAA', function() {
         },
         {
             'colorA': '#000000',
-            'colorB': '#848484',  // This should pass
+            'colorB': '#998899',  // This should pass
             'fontSize': 14
         },
         {

--- a/test/color-contrast-checker.js
+++ b/test/color-contrast-checker.js
@@ -55,6 +55,23 @@ describe('Supported Color Code Lengths', function() {
   });
 });
 
+describe('Supported Custom Ratio Inputs', function() {
+  it('should accept an integer', function() {
+    var result = ccc.isValidRatio(1);
+    expect(result).to.be.true;
+  });
+
+  it('should accept a float', function() {
+    var result = ccc.isValidRatio(3.2);
+    expect(result).to.be.true;
+  });
+
+  it('should reject a string', function() {
+    var result = ccc.isValidRatio("3.2");
+    expect(result).to.be.false;
+  });
+});
+
 describe('Convert Color from 3 digit to 6 digit', function() {
   it('should convert 3 digit color to 6 digit', function() {
     var result = ccc.convertColorToSixDigit("#FFF");
@@ -118,6 +135,22 @@ describe('Basic Validation for LevelAAA', function() {
   });
 });
 
+describe('Basic Validation for Custom Ratio', function() {
+  it('should return true when contrast is valid for three digit color codes', function() {
+   var result = ccc.isLevelCustom("#FFF", "#000", 14, 5);
+   expect(result).to.be.true;
+ });
+
+ it('should return true when contrast is valid', function() {
+   var result = ccc.isLevelCustom("#FFFFFF", "#000000", 14, 5);
+   expect(result).to.be.true;
+ });
+
+ it('should return false when contrast is invalid', function() {
+   var result = ccc.isLevelCustom("#000000", "#000000", 14, 5);
+   expect(result).to.be.false;
+ });
+});
 
 describe('Six Digit Pair Validation for LevelAAA', function() {
   var pairs = [
@@ -236,11 +269,60 @@ describe('Three Digit Pair Validation for LevelAAA', function() {
      }
      return objectsAreSame;
   }
-
   it('should return the expectedResults for checkPairs', function() {
     var results = ccc.checkPairs(pairs);
     expect(results).to.be.an('array');
     expect(results).to.have.lengthOf(6);
+    expect(objectsAreSame(results, expectedResults)).to.be.true;
+  }); 
+});
+
+  describe('Six Digit Pair Validation for Custom Ratio', function() {
+    var pairs = [
+        {
+            'colorA': '#000000',
+            'colorB': '#000000',  // This should fail
+            'fontSize': 14
+        },
+        {
+            'colorA': '#000000',
+            'colorB': '#FFFFFF',  // This should pass
+            'fontSize': 14
+        },
+        {
+            'colorA': '#000000',
+            'colorB': '#848484',  // This should pass
+            'fontSize': 14
+        },
+        {
+            'colorA': '#000000',
+            'colorB': '#656565',  // This should fail
+            'fontSize': 14
+        }
+    ];
+  
+  
+    var expectedResults = [ 
+      { customRatio: false },
+      { customRatio: true },
+      { customRatio: false },
+      { customRatio: false } ];
+  
+    function objectsAreSame(x, y) {
+       var objectsAreSame = true;
+       for(var propertyName in x) {
+          if(x[propertyName].customRatio !== y[propertyName].customRatio) {
+             objectsAreSame = false;
+             break;
+          }
+       }
+       return objectsAreSame;
+    }
+
+  it('should return the expectedResults for checkPairs', function() {
+    var results = ccc.checkPairs(pairs, 5.6);
+    expect(results).to.be.an('array');
+    expect(results).to.have.lengthOf(4);
     expect(objectsAreSame(results, expectedResults)).to.be.true;
   }); 
 });


### PR DESCRIPTION
This is a pretty big PR but it snowballed once I added a new feature and noticed the tests were failing when they shouldn't have been.

The contents of this can be split into 4 groups:

1. Adding in custom ratio options ( this is to allow users to check against more strict/more lenient ratios without installing another module)
2. Fixing Module bugs (Mostly due to incorrect regex)
3. Fixing bad test cases (Adding more coverage to catch regex errors more easily, updating with correct values for Luminescence  tests)
4. Adding in QoL changes for development (Eslint mostly)

If you have any specific questions about any of the changes let me know.